### PR TITLE
upgraded hazelcast and eureka-client versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
         <jdk.version>1.6</jdk.version>
         <hazelcast.version>3.9.3</hazelcast.version>
-        <eureka.client.version>1.7.2</eureka.client.version>
+        <eureka.client.version>1.8.6</eureka.client.version>
         <archaius.core>0.7.5</archaius.core>
 
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>
-        <hazelcast.version>3.8.2</hazelcast.version>
-        <eureka.client.version>1.6.2</eureka.client.version>
+        <hazelcast.version>3.9.3</hazelcast.version>
+        <eureka.client.version>1.7.2</eureka.client.version>
         <archaius.core>0.7.5</archaius.core>
 
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
fixes #5 
fixes #16 

This PR upgrades to the latest hazelcast and Eureka Client version.

I have tested with [Spring Cloud Finchley.M8](https://spring.io/blog/2018/03/02/spring-cloud-finchley-m8-is-available ) Release which is using Eureka Server 1.8.6
