### PR TITLE
Remove unknown property from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ It is optional. Default value is `true`.
 Below you can also find an example of Eureka client properties. 
 
 ```$properties
-hazelcast.environment=prod
 hazelcast.shouldUseDns=false
 hazelcast.datacenter=cloud
 hazelcast.name=hazelcast-test
@@ -103,7 +102,6 @@ The following is an example declarative configuration, equivalent to the example
                 <property name="self-registration">true</property>
                 <property name="namespace">hazelcast</property>
                 <property name="use-classpath-eureka-client-props">false</property>
-                <property name="environment">prod</property>
                 <property name="shouldUseDns">false</property>
                 <property name="datacenter">cloud</property>
                 <property name="name">hazelcast-test</property>
@@ -137,7 +135,6 @@ The following is an example declarative configuration.
 
 Below you can also find an example of Eureka client properties.
 ```$properties
-hazelcast.environment=prod
 hazelcast.shouldUseDns=false
 hazelcast.datacenter=cloud
 hazelcast.name=hazelcast-test
@@ -170,7 +167,6 @@ The following is an example declarative configuration, equivalent to the example
             <properties>
                 <property name="namespace">hazelcast</property>
                 <property name="use-classpath-eureka-client-props">false</property>
-                <property name="environment">prod</property>
                 <property name="shouldUseDns">false</property>
                 <property name="datacenter">cloud</property>
                 <property name="name">hazelcast-test</property>


### PR DESCRIPTION
The `hazelcast.environment` property appears in the Eureka client properties example in the README, but it is not a valid Eureka client property, so it is effectively ignored. When using Hazelcast configuration properties it will be rejected as unknown property when https://github.com/hazelcast/hazelcast/pull/12819 (Fail fast on unknown properties) is merged.
