### PR TITLE
Remove dependency to hazelcast-client in the 4.0 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.8</jdk.version>
-        <hazelcast.version>4.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>4.0-BETA-2</hazelcast.version>
         <eureka.client.version>1.8.6</eureka.client.version>
         <archaius.core>0.7.5</archaius.core>
 
@@ -181,22 +181,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
-            <version>${hazelcast.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>${log4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
-            <version>${hazelcast.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I think we should merge this one and then make a release of the plugin with the version `2.0`. To be ready to use it with Hazelcast `4.0`.