### PR TITLE
Bump jackson and httpclient versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,9 @@
         <javax.inject.version>1</javax.inject.version>
         <guava.version>30.1-jre</guava.version>
         <xstream.version>1.4.15</xstream.version>
+        <jackson.version>2.10.5</jackson.version>
+        <jackson.databind.version>2.10.5.1</jackson.databind.version>
+        <httpclient.version>4.5.13</httpclient.version>
 
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
@@ -199,6 +202,26 @@
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
             <version>${commons.configuration.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Overrides the dependency versions of Eureka client to prevent vulnerabilities.

Current Eureka client version:
https://github.com/hazelcast/hazelcast-eureka/blob/396744fcb908f607eb5dd488e99f4b0f7bdf958f/pom.xml#L34

which [depends](https://mvnrepository.com/artifact/com.netflix.eureka/eureka-client/1.10.11) on:

org.apache.httpcomponents » httpclient | 4.5.3 ([CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956))
com.fasterxml.jackson.core » jackson-databind | 2.9.10.6 ([CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490))
com.fasterxml.jackson.core » jackson-annotations | 2.9.10
com.fasterxml.jackson.core » jackson-core | 2.9.10




