### PR TITLE
Set TransportClientFactories in builder in EurekaOneDiscoveryStrategyFactory

### DIFF
--- a/src/main/java/com/hazelcast/eureka/one/EurekaOneDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/eureka/one/EurekaOneDiscoveryStrategyFactory.java
@@ -54,7 +54,7 @@ public class EurekaOneDiscoveryStrategyFactory
                                                   Map<String, Comparable> properties) {
         EurekaOneDiscoveryStrategyBuilder builder = new EurekaOneDiscoveryStrategyBuilder();
         builder.setDiscoveryNode(discoveryNode).setILogger(logger).setProperties(properties)
-                .setEurekaClient(eurekaClient).setGroupName(groupName);
+                .setEurekaClient(eurekaClient).setGroupName(groupName).setTransportClientFactories(clientFactories);
         return builder.build();
     }
 


### PR DESCRIPTION
Currently EurekaOneDiscoveryStrategyFactory allows setting TransportClientFactories, however, this is not included in the builder in the method newDiscoveryStrategy.
It looks like a missed spot in a commit related to this change:
https://github.com/hazelcast/hazelcast-eureka/commit/f37616bac9dc13067e75e7880a841ee0109c35dc